### PR TITLE
Adding reports filtering

### DIFF
--- a/apps/frontend/components/Filters/SearchFilters.tsx
+++ b/apps/frontend/components/Filters/SearchFilters.tsx
@@ -1,7 +1,6 @@
 import { Box, Button } from '@mui/material';
 import { Dispatch, SetStateAction } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { FormattedMessage } from 'react-intl';
 
 import { DateRange, DateRangeFilter } from './DateRangeFilter';
 import { DisasterFilter } from './DisasterFilter';
@@ -16,9 +15,11 @@ export interface SearchFormData {
 export const SearchFilters = ({
   initSearchFormData,
   setSearchFormData,
+  submitButtonContent,
 }: {
   initSearchFormData: SearchFormData;
   setSearchFormData: Dispatch<SetStateAction<SearchFormData>>;
+  submitButtonContent: JSX.Element;
 }): JSX.Element => {
   const { control, handleSubmit } = useForm<SearchFormData>({
     defaultValues: initSearchFormData,
@@ -53,10 +54,7 @@ export const SearchFilters = ({
       />
       <Box display="flex" justifyContent="center" mb={2}>
         <Button sx={{ color: 'white' }} type="submit">
-          <FormattedMessage
-            id="navigation.forms.search"
-            defaultMessage="Search"
-          />
+          {submitButtonContent}
         </Button>
       </Box>
     </form>

--- a/apps/frontend/components/pages/Forms/Search.tsx
+++ b/apps/frontend/components/pages/Forms/Search.tsx
@@ -2,6 +2,7 @@ import { Box } from '@mui/material';
 import { DisasterMapping } from '@wfp-dmp/interfaces';
 import dayjs from 'dayjs';
 import { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 
 import {
   SearchFilters,
@@ -33,6 +34,12 @@ export const FormSearch = () => {
       <SearchFilters
         initSearchFormData={searchFormData}
         setSearchFormData={setSearchFormData}
+        submitButtonContent={
+          <FormattedMessage
+            id="navigation.forms.search"
+            defaultMessage="Search"
+          />
+        }
       />
       <TableDisplay isLoading={isLoading} forms={formData} />
     </Box>

--- a/apps/frontend/components/pages/Report/ReportContainer.tsx
+++ b/apps/frontend/components/pages/Report/ReportContainer.tsx
@@ -1,0 +1,44 @@
+import { Box } from '@mui/material';
+import { DisasterMapping } from '@wfp-dmp/interfaces';
+import dayjs from 'dayjs';
+import { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  SearchFilters,
+  SearchFormData,
+} from 'components/Filters/SearchFilters';
+
+const defaultSearchReportData: SearchFormData = {
+  disTyp: DisasterMapping['flood'],
+  region: {
+    province: '',
+    district: '',
+    commune: '',
+  },
+  dateRange: {
+    startDate: dayjs(new Date()),
+    endDate: dayjs(new Date()),
+  },
+};
+
+export const ReportContainer = () => {
+  const [searchReportData, setSearchReportData] = useState(
+    defaultSearchReportData,
+  );
+
+  return (
+    <Box display="flex" flexDirection="column">
+      <SearchFilters
+        initSearchFormData={searchReportData}
+        setSearchFormData={setSearchReportData}
+        submitButtonContent={
+          <FormattedMessage
+            id="report_page.showReport"
+            defaultMessage="Show Report"
+          />
+        }
+      />
+    </Box>
+  );
+};

--- a/apps/frontend/components/pages/Report/index.ts
+++ b/apps/frontend/components/pages/Report/index.ts
@@ -1,0 +1,1 @@
+export { ReportContainer } from './ReportContainer';

--- a/apps/frontend/pages/report.tsx
+++ b/apps/frontend/pages/report.tsx
@@ -1,10 +1,11 @@
 import { NextPage } from 'next';
 
 import { LayoutWithNav } from 'components/Layout';
+import { ReportContainer } from 'components/pages/Report';
 
 const ReportPage: NextPage = () => (
   <LayoutWithNav>
-    <div />
+    <ReportContainer />
   </LayoutWithNav>
 );
 

--- a/apps/frontend/translations/en.json
+++ b/apps/frontend/translations/en.json
@@ -81,6 +81,9 @@
       "review_link": "Review and Approval"
     }
   },
+  "report_page": {
+    "showReport": "Show Report"
+  },
   "provinces": {
     "01": "Banteay Meanchey",
     "02": "Battambang",

--- a/apps/frontend/translations/km.json
+++ b/apps/frontend/translations/km.json
@@ -81,6 +81,9 @@
       "review_link": "Review and Approval"
     }
   },
+  "report_page": {
+    "showReport": "បង្ហាញរបាយការណ៍"
+  },
   "provinces": {
     "01": "ខេត្តបន្ទាយមានជ័យ",
     "02": "ខេត្តបាត់ដំបង",


### PR DESCRIPTION
AAUser, in the menu bar, when I click on the Reports tab, I see the common section at the top of the page where I can select disaster location, disaster type, and date submitted