### PR TITLE
fix: refresh token cookie allowing cross site

### DIFF
--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -20,6 +20,7 @@ export class AuthController {
     res.cookie(REFRESH_TOKEN, refresh, {
       httpOnly: true,
       secure: process.env.NODE_ENV !== Environment.Development,
+      sameSite: 'none',
     });
 
     return res.send({ access });


### PR DESCRIPTION
Fix :  refresh token cookie is not same because it doesn't work on cross sites. After 10min the user is automatically disconnected.


How to test when merged in main?
- go to the staging url
- remove your the cookies and reconnect. In the the dev tools > applications you should see a cookie called refresh_token