### PR TITLE
fix(backend): filter the forms on entry date

### DIFF
--- a/apps/backend/src/modules/kobo/kobo.service.ts
+++ b/apps/backend/src/modules/kobo/kobo.service.ts
@@ -53,7 +53,7 @@ export class KoboService {
       {
         params: {
           query: {
-            _submission_time: { $gt: formatDateToStringDate(startDate) },
+            [koboKeys[disasterType].entryDate]: { $gt: formatDateToStringDate(startDate) },
             [koboKeys[disasterType].province]: province,
           },
         },
@@ -88,7 +88,7 @@ export class KoboService {
             [koboKeys[disasterType].district]: district,
             [koboKeys[disasterType].commune]: commune,
             [koboKeys[disasterType].disTyp]: disTyp,
-            _submission_time: { $gte: startDate, $lte: endDate },
+            [koboKeys[disasterType].entryDate]: { $gte: startDate, $lte: endDate },
           },
         },
       },

--- a/apps/backend/src/modules/kobo/kobo.service.ts
+++ b/apps/backend/src/modules/kobo/kobo.service.ts
@@ -53,7 +53,7 @@ export class KoboService {
       {
         params: {
           query: {
-            [koboKeys[disasterType].entryDate]: { $gt: formatDateToStringDate(startDate) },
+            [koboKeys[disasterType].entryDate]: { $gte: formatDateToStringDate(startDate) },
             [koboKeys[disasterType].province]: province,
           },
         },


### PR DESCRIPTION
We were previously using the timestamp _submission_time to filter the forms to retrieve.
It was creating some issues because we were comparing a date with a timestamp.

We now use the Date_report field which is a date.