### PR TITLE
fix(backend): fix refresh token for local dev

### DIFF
--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -20,7 +20,7 @@ export class AuthController {
     res.cookie(REFRESH_TOKEN, refresh, {
       httpOnly: true,
       secure: process.env.NODE_ENV !== Environment.Development,
-      sameSite: 'none',
+      sameSite: process.env.NODE_ENV !== Environment.Development ? 'none' : undefined,
     });
 
     return res.send({ access });


### PR DESCRIPTION
secure is set to false when we use the local environment in the refresh token cookie.
In this case, if sameSite is set to none the cookie cannot be installed.