### PR TITLE
feat(frontend): add language icon

### DIFF
--- a/apps/frontend/components/NavBar/NavMenuContent.tsx
+++ b/apps/frontend/components/NavBar/NavMenuContent.tsx
@@ -1,5 +1,6 @@
 import ContentPasteIcon from '@mui/icons-material/ContentPaste';
 import HistoryIcon from '@mui/icons-material/History';
+import LanguageIcon from '@mui/icons-material/Language';
 import LogoutIcon from '@mui/icons-material/Logout';
 import StarIcon from '@mui/icons-material/Star';
 import SupervisorAccountIcon from '@mui/icons-material/SupervisorAccount';
@@ -148,7 +149,11 @@ export const NavMenuContent = (): JSX.Element => {
         )}
       </List>
       <FormControl sx={{ padding: 4 }}>
-        <Select value={language} onChange={handleLanguageChange}>
+        <Select
+          value={language}
+          onChange={handleLanguageChange}
+          startAdornment={<LanguageIcon />}
+        >
           <MenuItem value="en">
             <FormattedMessage
               id="navigation.language.english"

--- a/apps/frontend/components/NavBar/NavMenuContent.tsx
+++ b/apps/frontend/components/NavBar/NavMenuContent.tsx
@@ -1,6 +1,6 @@
 import ContentPasteIcon from '@mui/icons-material/ContentPaste';
-import LanguageIcon from '@mui/icons-material/Language';
 import HomeIcon from '@mui/icons-material/Home';
+import LanguageIcon from '@mui/icons-material/Language';
 import LogoutIcon from '@mui/icons-material/Logout';
 import StarIcon from '@mui/icons-material/Star';
 import SupervisorAccountIcon from '@mui/icons-material/SupervisorAccount';
@@ -152,7 +152,7 @@ export const NavMenuContent = (): JSX.Element => {
         <Select
           value={language}
           onChange={handleLanguageChange}
-          startAdornment={<LanguageIcon />}
+          startAdornment={<LanguageIcon sx={{ marginRight: 1 }} />}
         >
           <MenuItem value="en">
             <FormattedMessage


### PR DESCRIPTION
### Description
Add a globe icon left of the language selector to help users find the switch to English.

It uses the MUI Language icon

### Screenshots
![image](https://user-images.githubusercontent.com/24255041/236617428-29c205a5-85a5-4bec-a013-39ec2f9c623e.png)

### Linked issue
Related to #67 