### PR TITLE
fix(devops): add standalone folder during build

### DIFF
--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -40,6 +40,9 @@ const nextConfig = {
   swcMinify: true,
   images: { unoptimized: true },
 
+  // standalone folder for deploys
+  output: 'standalone',
+
   headers: async () => [
     {
       // Apply these headers to all routes in your application.


### PR DESCRIPTION
Trying to fix bundle size errors on amplify by using the standalone folder build output