### PR TITLE
fix: cast number to string when updating a value in table

### DIFF
--- a/apps/frontend/utils/tableFormatting.tsx
+++ b/apps/frontend/utils/tableFormatting.tsx
@@ -24,7 +24,7 @@ export const getColumnSetup = (
     renderHeader: (params: GridColumnHeaderParams) => (
       <FormattedMessage id={`table.${disaster}.column.${params.field}`} />
     ),
-    // cast the modified value from number to string
+    // cast the modified value from number to string to stay consistent with Kobo
     valueParser: (value: string | number | undefined) => {
       return value === undefined ? undefined : String(value);
     },


### PR DESCRIPTION
The backend receives stringified numbers because Kobo manipulates stringified numbers.
Currently, on edit, we send numbers to the backend that rejects the request.
Fix: we cast the number from the tables to string.