### PR TITLE
Fix border issue for last column

### DIFF
--- a/apps/frontend/components/DisasterTable/DisasterTable.tsx
+++ b/apps/frontend/components/DisasterTable/DisasterTable.tsx
@@ -189,7 +189,7 @@ export const DisasterTable = ({
       ]
     : _updatedColumns;
 
-  const totalWidth = sum(updatedColumns.map(x => x.width ?? 0));
+  const totalWidth = sum(updatedColumns.map(x => x.width ?? 0)) + 2; // 2px for borders on the sides
   const maxPrintWidth = 1600; // Maximum print width in pixels
   const scaleFactor = Math.min(1, maxPrintWidth / totalWidth);
 


### PR DESCRIPTION
## Issue #162 

The rows of the table were overflowing, therefore the last column was cut by 2px. That was mostly visible when the last column was focused and the outline was shown.

![image](https://github.com/user-attachments/assets/b4d24fe7-d872-47bd-a488-0c82196e2f0d)

## Changes

- Fixed by adding 2px to the container's width to compensate for the borders on the sides.

![Screenshot from 2024-10-09 15-49-23](https://github.com/user-attachments/assets/7cabcdd4-2e36-428b-a028-84511d256459)
