### PR TITLE
Fix table printing extra space

### DIFF
--- a/apps/frontend/components/DisasterTable/DisasterTable.tsx
+++ b/apps/frontend/components/DisasterTable/DisasterTable.tsx
@@ -203,8 +203,7 @@ export const DisasterTable = ({
     zIndex: 1,
   };
 
-  // TODO - Debug why the table is not printing correctly when there are more than 28 rows
-  const rowsPerPage = Math.min(28, Math.floor(20 / scaleFactor));
+  const rowsPerPage = Math.floor(28 / scaleFactor);
   const dataChunks = useMemo(() => {
     return isPrinting ? chunk(nonEmptyData, rowsPerPage) : [nonEmptyData];
   }, [isPrinting, nonEmptyData, rowsPerPage]);
@@ -283,9 +282,7 @@ export const DisasterTable = ({
                   <DataGrid
                     sx={{
                       '@media print': {
-                        transform: `scale(${scaleFactor})`,
-                        transformOrigin: 'top left',
-                        overflow: 'unset',
+                        zoom: scaleFactor,
                       },
                       '& .MuiDataGrid-row.highlight-1': {
                         background: `${colors.color1}`,

--- a/apps/frontend/components/PrintFooter/PrintFooter.tsx
+++ b/apps/frontend/components/PrintFooter/PrintFooter.tsx
@@ -28,6 +28,7 @@ export const PrintFooter = (): JSX.Element => {
           display: 'flex',
           flexDirection: 'column',
           padding: '2rem',
+          pageBreakInside: 'avoid',
         },
         '@media screen': {
           display: 'none',

--- a/apps/frontend/components/PrintFooter/PrintFooter.tsx
+++ b/apps/frontend/components/PrintFooter/PrintFooter.tsx
@@ -28,9 +28,6 @@ export const PrintFooter = (): JSX.Element => {
           display: 'flex',
           flexDirection: 'column',
           padding: '2rem',
-          // TODO - adjust when the first page bug is fixed.
-          // See max number of rows in DisasterTable.tsx
-          marginTop: '-14rem',
         },
         '@media screen': {
           display: 'none',


### PR DESCRIPTION
## Issue

When printing the disaster table it only prints 28 rows per page and breaks the rest of the table to the next page, leaving extra space at the bottom. This is happening because we use `transform: scale()` to fit the table into the printing area. Transform works after the initial table have been rendered, therefore the page break happens at this point and then the table is scaled down to match the printing area width.

![2024-10-10_16-38](https://github.com/user-attachments/assets/22b202c6-ca67-488d-9d9b-9768ceb22ccb)

## Changes

 Replace `transform` with `zoom` which is equivalent and effective immediately on render.

![image](https://github.com/user-attachments/assets/6dc6f557-3226-474a-8d1b-20847d80a72b)

[report.pdf](https://github.com/user-attachments/files/17329157/report.pdf)
